### PR TITLE
fix index.js sendFlex function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 //不成功
 module.exports = async function App(context) {
-  await context.sendFlex({
+  await context.sendFlex('Hello World!', {
     type: 'bubble',
     body: {
       type: 'box',


### PR DESCRIPTION
參考 bottender 原本的 source code: https://github.com/louis70109/bottender/blob/master/packages/bottender/src/line/LineContext.ts#L529

```javascript
 sendFlex(
    altText: string,
    flex: LineTypes.FlexContainer,
    options?: LineTypes.MessageOptions
  ) 
```
這邊原本只填了`flex`的選項卻少了`altText`這個參數才會出錯
